### PR TITLE
Add missing autoprefixer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Andrej Gajdos",
   "license": "MIT",
   "devDependencies": {
+    "autoprefixer": "^6.3.7",
     "babel": "^6.5.2",
     "babel-core": "^6.5.2",
     "babel-loader": "^6.2.2",


### PR DESCRIPTION
There was a failure when running `$ npm install` of your project and this was fixed with this trivial addition. I thought I'd pass this info on in a pull request.
