### PR TITLE
Simplifies route to bootstrap.css

### DIFF
--- a/src/script/components/button.jsx
+++ b/src/script/components/button.jsx
@@ -2,7 +2,7 @@ var React = require('react');
 var buttonStyle = require('./button.scss');
 
 var bootstrap = require('bootstrap');
-var bootstrapStyle = require("../../../node_modules/bootstrap/dist/css/bootstrap.css");
+var bootstrapStyle = require("bootstrap/dist/css/bootstrap.css");
 
 export class Button extends React.Component {
   render() {


### PR DESCRIPTION
Require without relative path indicators defaults to node_modules folder.
